### PR TITLE
Удалить String.class из groups аннотации SizeAfterTrim

### DIFF
--- a/main-service/src/main/java/ru/practicum/main/service/validator/SizeAfterTrim.java
+++ b/main-service/src/main/java/ru/practicum/main/service/validator/SizeAfterTrim.java
@@ -17,7 +17,7 @@ public @interface SizeAfterTrim {
 
     String message() default "string size after trim should be between {min} and {max} included";
 
-    Class<?>[] groups() default {String.class};
+    Class<?>[] groups() default {};
 
     Class<?>[] payload() default {};
 }


### PR DESCRIPTION
Исправление `@SizeAfterTrim`