### PR TITLE
Feature endpoint admin

### DIFF
--- a/main-service/src/main/java/ru/practicum/main/service/comment/controller/AdminCommentController.java
+++ b/main-service/src/main/java/ru/practicum/main/service/comment/controller/AdminCommentController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import ru.practicum.main.service.comment.service.CommentService;
 
 @Slf4j
 @RestController
@@ -17,14 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @Validated
 public class AdminCommentController {
-//    private final CommentService commentService;
+    private final CommentService commentService;
 
     @DeleteMapping("/{commentId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteComment(@Positive @PathVariable Long eventId,
                               @Positive @PathVariable Long commentId) {
         log.info("DELETE /admin/events/{}/comments/{}", eventId, commentId);
-//        commentService.deleteComment();
+        commentService.deleteCommentAdmin(eventId, commentId);
         log.info("Был успешно удалён комментарий event id = {}, comment id = {}", eventId, commentId);
     }
 }

--- a/main-service/src/main/java/ru/practicum/main/service/comment/controller/AdminCommentController.java
+++ b/main-service/src/main/java/ru/practicum/main/service/comment/controller/AdminCommentController.java
@@ -1,0 +1,30 @@
+package ru.practicum.main.service.comment.controller;
+
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/admin/events/{eventId}/comments")
+@RequiredArgsConstructor
+@Validated
+public class AdminCommentController {
+//    private final CommentService commentService;
+
+    @DeleteMapping("/{commentId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteComment(@Positive @PathVariable Long eventId,
+                              @Positive @PathVariable Long commentId) {
+        log.info("DELETE /admin/events/{}/comments/{}", eventId, commentId);
+//        commentService.deleteComment();
+        log.info("Был успешно удалён комментарий event id = {}, comment id = {}", eventId, commentId);
+    }
+}


### PR DESCRIPTION
Удаление комментария администратором:
DELETE `/admin/events/{eventId}/comments/{commentId}`

Параметры:

- eventId* ($int64) - id события
- commentId* ($int64) - id комментария

Ответы сервера:

- Code 204 - комментарий удалён
- Code 400 - запрос составлен некорректно
- Code 404 - не найден комментарий по указанному пути